### PR TITLE
added board expansion methods

### DIFF
--- a/lib/board.py
+++ b/lib/board.py
@@ -108,8 +108,8 @@ class Board:
         return [self._positions[c] for c in self._border_coords]
 
         
-    def size(self):
-        return len(self._positions)
+    size = property(fget = lambda s: len(s._positions))
+    
         
     def all_nodes(self) -> list[BoardNode]:
         return list(self._positions.values())

--- a/lib/board.py
+++ b/lib/board.py
@@ -99,8 +99,8 @@ class Board:
                         if not existing_node.is_border():
                             self._border_coords.discard(
                                 existing_node.get_location())
-                    if new_node.is_border():
-                        self._border_coords.add(new_node.get_location())
+                if new_node.is_border():
+                    self._border_coords.add(new_node.get_location())
                 created_count += 1
         return created_count
 

--- a/lib/board.py
+++ b/lib/board.py
@@ -55,18 +55,18 @@ class BoardNode:
         
 
 class Board:
-    _positions: dict[CubeCoordinate: BoardNode]
+    _nodemap: dict[CubeCoordinate: BoardNode]
     _border_coords: set[CubeCoordinate]
 
     def __init__(self):
-        self._positions = {}
+        self._nodemap = {}
         self._border_coords = set()
         self._build_new_board()
 
     def _build_new_board(self):
         origin = BoardNode(CubeCoordinate(0, 0, 0),
                            tile=Tile(TileType.PLAINS, [TileType.PLAINS] * 6))
-        self._positions[origin.get_location()] = origin
+        self._nodemap[origin.get_location()] = origin
         self.expand(origin.get_location())
 
     def expand(self, location: CubeCoordinate) -> int:
@@ -75,25 +75,25 @@ class Board:
 
         Returns number of tiles created
         """
-        if location not in self._positions:
+        if location not in self._nodemap:
             raise ValueError(
                 f"No tile found at location: {location}")
 
-        node = self._positions[location]
+        node = self._nodemap[location]
         self._border_coords.discard(location)
         created_count = 0
         for i, neighbor in enumerate(node._neighbors):
             if not neighbor:
                 # create a new neighbor and form link if slot is empty
                 new_node = BoardNode(location.adjacent(i), None)
-                self._positions[new_node.get_location()] = new_node
+                self._nodemap[new_node.get_location()] = new_node
                 node._neighbors[i] = new_node
 
                 # search existing nodes and form new two way connections
                 for j in range(6):
                     pos = new_node.get_location().adjacent(j)
-                    if pos in self._positions:
-                        existing_node = self._positions[pos]
+                    if pos in self._nodemap:
+                        existing_node = self._nodemap[pos]
                         new_node.set_neighbor(j, existing_node)
                         existing_node.set_neighbor(opposite(j), new_node)
                         if not existing_node.is_border():
@@ -105,14 +105,14 @@ class Board:
         return created_count
 
     def border_nodes(self):
-        return [self._positions[c] for c in self._border_coords]
+        return [self._nodemap[c] for c in self._border_coords]
 
         
-    size = property(fget = lambda s: len(s._positions))
+    size = property(fget = lambda s: len(s._nodemap))
     
         
     def all_nodes(self) -> list[BoardNode]:
-        return list(self._positions.values())
+        return list(self._nodemap.values())
 
         
     def __str__(self):

--- a/lib/board.py
+++ b/lib/board.py
@@ -1,44 +1,53 @@
+from __future__ import annotations
 from lib.tile import Tile, TileType
 from lib.cubecoordinate import CubeCoordinate
+from lib.util import opposite
 
 class BoardNode:
+    _tile: Tile | None
+    _location: CubeCoordinate
+    _neighbors: list[BoardNode | None]
+
     
     def __init__(self, cubecoord, tile=None):
-        self.__tile = tile
-        self.__location = cubecoord
-        self.__neighbors = [None] * 6
+        self._tile = tile
+        self._location = cubecoord
+        self._neighbors = [None] * 6
         
         
     def get_location(self):
-        return self.__location
+        return self._location
         
         
     def set_tile(self,tile):
-        self.__tile = tile
+        self._tile = tile
         
         
     def get_tile(self):
-        return self.__tile
+        return self._tile
         
         
     def has_tile(self):
-        return self.__tile != None
+        return self._tile != None
         
+    def get_neighbors(self) -> list[BoardNode | None]:
+        return self._neighbors
+
+    def get_neighbor(self, side: int) -> BoardNode | None:
+        return self._neighbors[side % 6]
         
-    def get_neighbors(self, side=None):
-        if side != None:
-            return self.__neighbors[side%6]
-        return self.__neighbors
-        
-        
-    def set_neighbor(self,side,node):
-        self.__neighbors[side%6] = node
-        
+    def set_neighbor(self, side: int, node: BoardNode | None) -> None:
+        self._neighbors[side % 6] = node
+
+    def is_border(self) -> bool:
+        """Returns true if this node is on the outer perimeter of the board"""
+        return None in self._neighbors
+
         
     def __str__(self):
         if self.has_tile():
-            return f"<Full BoardNode at {self.__location}>"
-        return f"<Empty BoardNode at {self.__location}>"
+            return f"<Full BoardNode at {self._location}>"
+        return f"<Empty BoardNode at {self._location}>"
         
         
     def __repr__(self):
@@ -46,47 +55,65 @@ class BoardNode:
         
 
 class Board:
-    
+    _positions: dict[CubeCoordinate: BoardNode]
+    _border_coords: set[CubeCoordinate]
+
     def __init__(self):
-        self.__build_new_board()
-        self.__edgeNodes = self.__rootNode.get_neighbors()
-        
-        
-    def __build_new_board(self):
-        self.__rootNode = BoardNode(
-            CubeCoordinate(0,0,0),
-            tile=Tile(TileType.PLAINS, [TileType.PLAINS] * 6)
-        )
-        self.__allNodes = set([self.__rootNode])
-        for i in range(6):
-            newNode = BoardNode(self.__rootNode.get_location().adjacent(i))
-            self.__allNodes.add(newNode)
-            # get nodes adjacent to new one
-            ccwNeighbor = self.__rootNode.get_neighbors(side=i-1)
-            cwNeighbor = self.__rootNode.get_neighbors(side=i+1)
-            # bi-directional connection
-            self.__rootNode.set_neighbor(i,newNode)
-            newNode.set_neighbor(i+3,self.__rootNode)
-            # make auxillary connections if possible
-            if ccwNeighbor != None:
-                newNode.set_neighbor(i+3+1,ccwNeighbor)
-                ccwNeighbor.set_neighbor(i+3-2,newNode)
-            if cwNeighbor != None:
-                newNode.set_neighbor(i+3-1,cwNeighbor)
-                cwNeighbor.set_neighbor(i+3+1,newNode)
-        
-        
-    def edge_nodes(self):
-        return self.__edgeNodes
-        
+        self._positions = {}
+        self._border_coords = set()
+        self._build_new_board()
+
+    def _build_new_board(self):
+        origin = BoardNode(CubeCoordinate(0, 0, 0),
+                           tile=Tile(TileType.PLAINS, [TileType.PLAINS] * 6))
+        self._positions[origin.get_location()] = origin
+        self.expand(origin.get_location())
+
+    def expand(self, location: CubeCoordinate) -> int:
+        """Create tiles on available sides around source tile and forms all
+        valid neighbor connections.
+
+        Returns number of tiles created
+        """
+        if location not in self._positions:
+            raise ValueError(
+                f"No tile found at location: {location}")
+
+        node = self._positions[location]
+        self._border_coords.discard(location)
+        created_count = 0
+        for i, neighbor in enumerate(node._neighbors):
+            if not neighbor:
+                # create a new neighbor and form link if slot is empty
+                new_node = BoardNode(location.adjacent(i), None)
+                self._positions[new_node.get_location()] = new_node
+                node._neighbors[i] = new_node
+
+                # search existing nodes and form new two way connections
+                for j in range(6):
+                    pos = new_node.get_location().adjacent(j)
+                    if pos in self._positions:
+                        existing_node = self._positions[pos]
+                        new_node.set_neighbor(j, existing_node)
+                        existing_node.set_neighbor(opposite(j), new_node)
+                        if not existing_node.is_border():
+                            self._border_coords.discard(
+                                existing_node.get_location())
+                    if new_node.is_border():
+                        self._border_coords.add(new_node.get_location())
+                created_count += 1
+        return created_count
+
+    def border_nodes(self):
+        return [self._positions[c] for c in self._border_coords]
+
         
     def size(self):
-        return len(self.__allNodes)
+        return len(self._positions)
         
-        
-    def all_nodes(self):
-        return self.__allNodes
-        
+    def all_nodes(self) -> list[BoardNode]:
+        return list(self._positions.values())
+
         
     def __str__(self):
-        return f"<Board object: {len(self.__edgeNodes)} edge nodes>"
+        return f"<Board object: {len(self._border_coords)} edge nodes>"

--- a/lib/cubecoordinate.py
+++ b/lib/cubecoordinate.py
@@ -34,7 +34,10 @@ class CubeCoordinate:
         
     def __eq__(self, cc):
         return self.q == cc.q and self.r == cc.r and self.s == cc.s
-        
+
+    def __hash__(self) -> int:
+        return hash((self.q, self.r, self.s))
+
         
     def __str__(self):
         return f"<Cube coordinate ({self.__q}, {self.__r}, {self.__s})>"

--- a/lib/util.py
+++ b/lib/util.py
@@ -1,0 +1,5 @@
+def opposite(index: int) -> int:
+    """Returns the opposite side index from an adjacent tile given an input 
+    side index
+    """
+    return (index + 3) % 6

--- a/main.py
+++ b/main.py
@@ -4,4 +4,4 @@ from lib.board import Board
 if __name__ == "__main__":
     b = Board()
     print(b)
-    print(b._positions)
+    print(b._nodemap)

--- a/main.py
+++ b/main.py
@@ -4,4 +4,4 @@ from lib.board import Board
 if __name__ == "__main__":
     b = Board()
     print(b)
-    print(b.edge_nodes())
+    print(b._positions)

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -7,7 +7,7 @@ class CreationTestCase(TestCase):
 
     def test_creation_normal(self):
         b = Board()
-        self.assertEqual(b.size(), 7)
+        self.assertEqual(b.size, 7)
         self.assertEqual(len(b.border_nodes()), 6)
         self.assertTrue(all(i in b._positions for i in b._border_coords))
         self.assertTrue(
@@ -28,7 +28,7 @@ class CreationTestCase(TestCase):
         new_count2 = b.expand(p2)
         self.assertEqual(new_count1, 3)
         self.assertEqual(new_count2, 2)
-        self.assertEqual(b.size(), 12)
+        self.assertEqual(b.size, 12)
         self.assertEqual(len(b.border_nodes()), 9)
         self.assertFalse(p1 in b._border_coords)
         self.assertFalse(p2 in b._border_coords)

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -9,18 +9,18 @@ class CreationTestCase(TestCase):
         b = Board()
         self.assertEqual(b.size, 7)
         self.assertEqual(len(b.border_nodes()), 6)
-        self.assertTrue(all(i in b._positions for i in b._border_coords))
+        self.assertTrue(all(i in b._nodemap for i in b._border_coords))
         self.assertTrue(
-            not any(b._positions[i].has_tile() for i in b._border_coords))
-        self.assertTrue(sum(i.has_tile() for i in b._positions.values()), 1)
+            not any(b._nodemap[i].has_tile() for i in b._border_coords))
+        self.assertTrue(sum(i.has_tile() for i in b._nodemap.values()), 1)
 
     def test_expand_board(self):
         b = Board()
 
         p1 = CubeCoordinate(1, 0, -1)
         p2 = CubeCoordinate(0, 1, -1)
-        self.assertTrue(p1 in b._positions)
-        self.assertTrue(p2 in b._positions)
+        self.assertTrue(p1 in b._nodemap)
+        self.assertTrue(p2 in b._nodemap)
         self.assertTrue(p1 in b._border_coords)
         self.assertTrue(p2 in b._border_coords)
 

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -13,25 +13,61 @@ class CreationTestCase(TestCase):
         self.assertTrue(
             not any(b._nodemap[i].has_tile() for i in b._border_coords))
         self.assertTrue(sum(i.has_tile() for i in b._nodemap.values()), 1)
+        
+        
+class InterfaceTestCase(TestCase):
+
+    def setUp(self):
+        self.b = Board()
+        
 
     def test_expand_board(self):
-        b = Board()
-
         p1 = CubeCoordinate(1, 0, -1)
         p2 = CubeCoordinate(0, 1, -1)
-        self.assertTrue(p1 in b._nodemap)
-        self.assertTrue(p2 in b._nodemap)
-        self.assertTrue(p1 in b._border_coords)
-        self.assertTrue(p2 in b._border_coords)
+        self.assertTrue(p1 in self.b._nodemap)
+        self.assertTrue(p2 in self.b._nodemap)
+        self.assertTrue(p1 in self.b._border_coords)
+        self.assertTrue(p2 in self.b._border_coords)
 
-        new_count1 = b.expand(p1)
-        new_count2 = b.expand(p2)
+        new_count1 = self.b.expand(p1)
+        new_count2 = self.b.expand(p2)
         self.assertEqual(new_count1, 3)
         self.assertEqual(new_count2, 2)
-        self.assertEqual(b.size, 12)
-        self.assertEqual(len(b.border_nodes()), 9)
-        self.assertFalse(p1 in b._border_coords)
-        self.assertFalse(p2 in b._border_coords)
-        self.assertTrue(CubeCoordinate(2, 0, -2) in b._border_coords)
-        self.assertTrue(CubeCoordinate(2, -1, -1) in b._border_coords)
-        self.assertTrue(CubeCoordinate(1, 1, -2) in b._border_coords)
+        self.assertEqual(self.b.size, 12)
+        self.assertEqual(len(self.b.border_nodes()), 9)
+        self.assertFalse(p1 in self.b._border_coords)
+        self.assertFalse(p2 in self.b._border_coords)
+        self.assertTrue(CubeCoordinate(2, 0, -2) in self.b._border_coords)
+        self.assertTrue(CubeCoordinate(2, -1, -1) in self.b._border_coords)
+        self.assertTrue(CubeCoordinate(1, 1, -2) in self.b._border_coords)
+        
+        
+    def test_expand_board_hole(self):
+        coordsToExpand = [
+            CubeCoordinate(0,-1,1),
+            CubeCoordinate(0,-2,2),
+            CubeCoordinate(1,-3,2),
+            CubeCoordinate(2,-4,2),
+            CubeCoordinate(3,-4,1),
+            CubeCoordinate(4,-4,0),
+            CubeCoordinate(4,-3,-1),
+            CubeCoordinate(4,-2,-2),
+            CubeCoordinate(3,-1,-2),
+            CubeCoordinate(2,0,-2),
+            CubeCoordinate(1,0,-1)
+        ]
+        
+        newCounts = []
+        for coord in coordsToExpand:
+            newCounts.append(self.b.expand(coord))
+            
+        self.assertEqual(newCounts, [3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 0])
+        self.assertNotIn(CubeCoordinate(2,-2,0), self.b._nodemap)
+        
+        # fill in hole
+        newCount = self.b.expand(CubeCoordinate(1,-1,0))
+        
+        self.assertEqual(newCount, 1)
+        self.assertIn(CubeCoordinate(2,-2,0), self.b._nodemap)
+        self.assertFalse(self.b._nodemap[CubeCoordinate(2,-2,0)].is_border())
+        self.assertNotIn(CubeCoordinate(2,-2,0), self.b._border_coords)

--- a/test/test_board.py
+++ b/test/test_board.py
@@ -8,8 +8,30 @@ class CreationTestCase(TestCase):
     def test_creation_normal(self):
         b = Board()
         self.assertEqual(b.size(), 7)
-        self.assertEqual(len(b.edge_nodes()), 6)
-        self.assertTrue(all(i in b.all_nodes() for i in b.edge_nodes()))
-        self.assertTrue(not any(i.has_tile() for i in b.edge_nodes()))
-        self.assertTrue(sum(i.has_tile() for i in b.all_nodes()), 1)
-        
+        self.assertEqual(len(b.border_nodes()), 6)
+        self.assertTrue(all(i in b._positions for i in b._border_coords))
+        self.assertTrue(
+            not any(b._positions[i].has_tile() for i in b._border_coords))
+        self.assertTrue(sum(i.has_tile() for i in b._positions.values()), 1)
+
+    def test_expand_board(self):
+        b = Board()
+
+        p1 = CubeCoordinate(1, 0, -1)
+        p2 = CubeCoordinate(0, 1, -1)
+        self.assertTrue(p1 in b._positions)
+        self.assertTrue(p2 in b._positions)
+        self.assertTrue(p1 in b._border_coords)
+        self.assertTrue(p2 in b._border_coords)
+
+        new_count1 = b.expand(p1)
+        new_count2 = b.expand(p2)
+        self.assertEqual(new_count1, 3)
+        self.assertEqual(new_count2, 2)
+        self.assertEqual(b.size(), 12)
+        self.assertEqual(len(b.border_nodes()), 9)
+        self.assertFalse(p1 in b._border_coords)
+        self.assertFalse(p2 in b._border_coords)
+        self.assertTrue(CubeCoordinate(2, 0, -2) in b._border_coords)
+        self.assertTrue(CubeCoordinate(2, -1, -1) in b._border_coords)
+        self.assertTrue(CubeCoordinate(1, 1, -2) in b._border_coords)


### PR DESCRIPTION
Board class:
- replaced `allNodes` set with `_positions: dict[CubeCoordinate: BoardNode]` to map positions to tiles
- replaced `edgeNodes` set with `_border_coords: set[CubeCoordinate]`. Renaming helps avoid ambiguity with edge/node terminology
- added `expand` method. When given input node, it creates new nodes around it and forms all valid neighbor connections

Updated test cases

Also changed to keep with convention replaced double underscores with single underscore for private methods/attr